### PR TITLE
bugfix: close_position of a LONG pos on Bybit resulted in doubling

### DIFF
--- a/bot_logic.py
+++ b/bot_logic.py
@@ -156,7 +156,7 @@ def close_position(exchange_name, symbol):
         positions = get_positions().get(exchange_name, [])
         for pos in positions:
             if pos["symbol"] == symbol:
-                side = "sell" if pos["side"] == "buy" else "buy"
+                side = "sell" if (pos["side"] == "buy" or pos["side"] == "long") else "buy"
                 order = exchange.create_market_order(symbol, side, pos["contracts"])
                 logger.info(f"✅ Position closed: {order}")
                 return {"status": "success", "order": order}


### PR DESCRIPTION
I noticed the following bug: when trying to Close a LONG position on Bybit (by pressing red buttton), what actually happens is that the position gets doubled. Instead of placing and order of opposite direction (i.e. short order), the system places another LONG order of equal size, which results in doubling of the positon.

The reason is that on Bybit, the order direction is not "buy" or "sell", but rather "long" and "short", and the proposed patch fixes this problem.